### PR TITLE
correções

### DIFF
--- a/examples/operadores.pas
+++ b/examples/operadores.pas
@@ -1,0 +1,15 @@
+0
+ASDF 12.12< ===== abc12<< 175 >= 0x123abc 12.32 12.1 032 >32.1 . / * 
+program SomaNumeros;
+var
+
+begin
+  { Solicitar a entrada dos números
+  agora}
+  readln(numero1);
+end.
+
+
+0.1
+0.2
+0.3 0.12 0.21 0.021 


### PR DESCRIPTION
correção para nao listar os tokens de comentarios, considerar 0 como octal e aceitar os números com delimitadores. (ex.: 12.12<, dois tokens 12.12 float e < menor)